### PR TITLE
potentially broken location update

### DIFF
--- a/CaretakersApp/app/src/main/java/seniorproject/caretakers/caretakersapp/ui/fragments/LocationFragment.java
+++ b/CaretakersApp/app/src/main/java/seniorproject/caretakers/caretakersapp/ui/fragments/LocationFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.RectF;
 import android.location.Location;
+import android.location.LocationListener;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -56,21 +57,26 @@ public class LocationFragment extends Fragment {
     MapView mapView;
     GoogleMap map;
 
-    View.OnClickListener mLocationClickListener = new View.OnClickListener() {
+    LocationListener locationListener = new LocationListener() {
         @Override
-        public void onClick(View view) {
-            switch(view.getId()){
-                case R.id.test_button:
-                    text.setVisibility(View.VISIBLE);
-                    text.setText(latitude + ", " + longitude);
+        public void onLocationChanged(Location location) {
+            CameraUpdate center = CameraUpdateFactory.newLatLngZoom(new LatLng(location.getLatitude(), location.getLongitude()), 10);
+            map.animateCamera(center);
+        }
 
-                    /*Context context = view.getContext();
-                    CharSequence text = "Hello toast!";
-                    int duration = Toast.LENGTH_SHORT;
+        @Override
+        public void onStatusChanged(String provider, int status, Bundle extras) {
 
-                    Toast toast = Toast.makeText(context, text, duration);
-                    toast.show();*/
-            }
+        }
+
+        @Override
+        public void onProviderEnabled(String provider) {
+
+        }
+
+        @Override
+        public void onProviderDisabled(String provider) {
+
         }
     };
 
@@ -88,30 +94,33 @@ public class LocationFragment extends Fragment {
 
         try{
             MapsInitializer.initialize(this.getActivity());
-        }catch (GooglePlayServicesNotAvailableException e){
+        }catch (Exception e){
             e.printStackTrace();
         }
 
-        Location testLocation = new Location("");
-        testLocation.setLatitude(39.7392138);
-        testLocation.setLongitude(-104.9879518);
+        LocationManager locationManager = (LocationManager) inflater.getContext().getSystemService(Context.LOCATION_SERVICE);
 
-        CameraUpdate cameraUpdate = CameraUpdateFactory.newLatLngZoom(new LatLng(testLocation.getLatitude(),testLocation.getLongitude()), 10);
-        map.animateCamera(cameraUpdate);
+
+
+
+        Location testLocation = new Location("");
+//        testLocation.setLatitude(39.7392138);
+//        testLocation.setLongitude(-104.9879518);
+
 
         /*mLocationButton = (Button) rootView.findViewById(R.id.test_button);
         text = (TextView) rootView.findViewById(R.id.test_location);
-        ((Button)rootView.findViewById(R.id.test_button)).setOnClickListener(mLocationClickListener);
-
-        Location testLocation = new Location("");
-        testLocation.setLatitude(42.293535);
-        testLocation.setLongitude(-87.609434);*/
+        ((Button)rootView.findViewById(R.id.test_button)).setOnClickListener(mLocationClickListener);*/
 
 
-        /*LocationManager locationManager = (LocationManager) rootView.getContext().getSystemService(Context.LOCATION_SERVICE);
+        //LocationManager locationManager = (LocationManager) rootView.getContext().getSystemService(Context.LOCATION_SERVICE);
         Location location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
-        longitude = testLocation.getLongitude();
-        latitude = testLocation.getLatitude();*/
+
+        longitude = location.getLongitude();
+        latitude = location.getLatitude();
+
+        CameraUpdate cameraUpdate = CameraUpdateFactory.newLatLngZoom(new LatLng(location.getLatitude(),location.getLongitude()), 10);
+        map.animateCamera(cameraUpdate);
 
         return rootView;
     }


### PR DESCRIPTION
Adds a way for the app to detect location changes based off the GPS/network

Testing:
1. Start up emulator and app.
2. Open the Android Device Monitor (Tools->Android->Android Device Monitor). You should see your emulator on the left side. You might get an error when opening it. If you do close Android Studio and restart it as an admin. This may be a Windows thing only. 
3. Push coordinates to the emulator. (I think you get a confirmation or something within the logcat.)
4. Open up the location tab. It should zoom into wherever coordinates you entered.
5. Push a different set of coordinates.
6. Switch tabs and switch back into the location tab. You should be at your second set of coordinates. 

Possible bugs: This only works if the coordinates are able to be pushed first. If the DDMS service can't connect to the emulator and push the coordinates before going to the location tab, the app will crash. May just be an issue with my machine.

Branch TODO: Automatic camera update with new coordinates. 
                        onPause and onResume for location checking to save battery life
